### PR TITLE
Update serverless-sam-cli-using-invoke.md

### DIFF
--- a/doc_source/serverless-sam-cli-using-invoke.md
+++ b/doc_source/serverless-sam-cli-using-invoke.md
@@ -1,6 +1,6 @@
 # Invoking Functions Locally<a name="serverless-sam-cli-using-invoke"></a>
 
-You can invoke your function locally by using the `[sam local invoke](sam-cli-command-reference-sam-local-invoke.md)` command and providing its function logical ID and an event file\. Alternatively, `sam local invoke` also accepts `stdin` as an event\.
+You can invoke your function locally by using the [sam local invoke](sam-cli-command-reference-sam-local-invoke.md) command and providing its function logical ID and an event file\. Alternatively, `sam local invoke` also accepts `stdin` as an event\.
 
 **Note**  
 The `sam local invoke` command described in this section corresponds to the AWS CLI command [ `aws lambda invoke`](https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html)\. You can use either version of this command to invoke a Lambda function that you've uploaded to the AWS Cloud\.


### PR DESCRIPTION
Corrected malformed link

*Issue #, if available:*

*Description of changes:*
The link to the `sam local invoke` command was incorrectly enclosed in backquotes, rendering the link useless. I removed the backquotes so that the link would be rendered correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
